### PR TITLE
updated readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1372,7 +1372,6 @@ yarn create next-app .
 - [Special Guest Austin Griffith](https://twitter.com/austingriffith)!
 - [Speed Run Ethereum](https://speedrunethereum.com/) 
 ### More DeFi Learnings: 
-- [Speed Run Ethereum](https://speedrunethereum.com/)
 - [Defi-Minimal](https://github.com/smartcontractkit/defi-minimal/tree/main/contracts)
 - [Defi Dad](https://www.youtube.com/channel/UCatItl6C7wJp9txFMbXbSTg)
 


### PR DESCRIPTION
Redundancy: two links for Speed Run Ethereum. (lines 1373-1376, lesson 13 recap)