### PR TITLE
Corrected Hardhat Discord Link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1637,7 +1637,8 @@ Special thanks to [Matt Durkin](https://twitter.com/mdurkin92) for help with thi
 ### Community
 
 -   [Twitter](https://twitter.com/PatrickAlphaC)
--   [Hardhat Discord](https://discord.gg/9zk7snTfWe)
+-   [Hardhat Discord](https://hardhat.org/discord)
+-   [Ethereum Python Community Discord](https://discord.gg/9zk7snTfWe)
 -   [Chainlink Discord](https://discord.gg/2YHSAey)
 -   [Ethereum Discord](https://ethereum.org/en/)
 -   [Reddit ethdev](https://www.reddit.com/r/ethdev/)


### PR DESCRIPTION
Hardhatt discord link was pointing to Ethereum Python Community, so I fixed it also added the correct Hardhat discord link. 😊