### PR TITLE
updating broken link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1602,7 +1602,7 @@ Special thanks to [Matt Durkin](https://twitter.com/mdurkin92) for help with thi
 - [Eth-Security-ToolBox](https://github.com/trailofbits/eth-security-toolbox)
 ## Closing Thoughts
 -   [Best Practices](https://consensys.github.io/smart-contract-best-practices/)
--   [Attacks](https://consensys.github.io/smart-contract-best-practices/known_attacks/)
+-   [Attacks](https://consensys.github.io/smart-contract-best-practices/attacks/)
     -   [Oracle Attacks](https://hackernoon.com/how-dollar100m-got-stolen-from-defi-in-2021-price-oracle-manipulation-and-flash-loan-attacks-explained-3n6q33r1)
     -   [Re-entrancy Attacks](https://quantstamp.com/blog/what-is-a-re-entrancy-attack)
 -   [Damn Vulnerable Defi](https://www.damnvulnerabledefi.xyz/)


### PR DESCRIPTION
updating broken link of [known_attacks](https://consensys.github.io/smart-contract-best-practices/known_attacks/) does not work anymore, for the new one [attacks](https://consensys.github.io/smart-contract-best-practices/attacks/)