### PR TITLE
Update recommended testnet to Goerli

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,12 +25,12 @@ Welcome to the repository for the Ultimate Web3, Full Stack Solidity, and Smart 
 
 All code references have both a javascript and a typescript edition.
 
-Recommended Testnet: Rinkeby
+Recommended Testnet: Goerli
 
 # [Testnet Faucets](https://faucets.chain.link)
 Main Faucet: https://faucets.chain.link
 
-Backup Faucet: https://rinkebyfaucet.com/
+Backup Faucet: https://goerlifaucet.com/
 
 > ⚠️ All code associated with this course is for demo purposes only. They have not been audited and should not be considered production ready. Please use at your own risk. 
 


### PR DESCRIPTION
See Chainlink docs (https://docs.chain.link/docs/link-token-contracts/#:~:text=contract) which recommends Goerli testnet: "The Rinkeby network is officially deprecated and is no longer supported. Goerli is the recommended testnet for Chainlink on Ethereum."