### PR TITLE
changed link to WETH goerli token in Etherscan

### DIFF
--- a/README.md
+++ b/README.md
@@ -1347,7 +1347,7 @@ yarn create next-app .
 - [DAI](https://makerdao.com/en/)
 - [Uniswap](https://app.uniswap.org/)
 ## WETH - Wrapped ETH
-- [WETH Token Goerli Etherscan](https://goerli.etherscan.io/token/0x8b7fb00abb67ba04ce894b9e2769fe24a8409a6a)
+- [WETH Token Goerli Etherscan](https://goerli.etherscan.io/token/0xb4fbf271143f4fbf7b91a5ded31805e42b2208d6)
 - [WETH Token Mainnet](https://etherscan.io/token/0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2)
 ## Forking Mainnet
 - [Mainnet Forking](https://hardhat.org/hardhat-network/guides/mainnet-forking.html)


### PR DESCRIPTION
# Changed Link

In the README, Lesson 13, I've changed the link to the WETH goerli token in Etherscan to the correct one. 

 ## Old Link
![oldLink](https://user-images.githubusercontent.com/90318659/197581771-3c4db6df-7a3f-4d4a-8031-dae552dfc6f2.png)

## New Link
![newLink](https://user-images.githubusercontent.com/90318659/197581792-12e64fef-9eac-4803-99ce-a6d2214c14d3.png)
